### PR TITLE
If not logged in, redirect to the login page.

### DIFF
--- a/src/Http/Middleware/redirectIfNotWithRoleOfAdmin.php
+++ b/src/Http/Middleware/redirectIfNotWithRoleOfAdmin.php
@@ -18,6 +18,11 @@ class redirectIfNotWithRoleOfAdmin
      */
     public function handle($request, Closure $next, $role = 'super')
     {
+        // If not logged in, redirect to the login page.
+        if (!auth('admin')->user()) {
+            return redirect(route('admin.login'));
+        }
+
         $roles = auth('admin')->user()->/* @scrutinizer ignore-call */roles()->pluck('name');
         if (in_array('super', $roles->toArray())) {
             return $next($request);

--- a/src/MultiauthServiceProvider.php
+++ b/src/MultiauthServiceProvider.php
@@ -83,7 +83,7 @@ class MultiauthServiceProvider extends ServiceProvider
         if (file_exists($routeDir)) {
             $appRouteDir = scandir($routeDir);
             if (!$this->app->routesAreCached()) {
-                require in_array("{$prefix}.php", $appRouteDir) ? base_path("routes/{$prefix}.php") : $path;
+                $path = in_array("{$prefix}.php", $appRouteDir) ? base_path("routes/{$prefix}.php") : $path;
             }
         }
 


### PR DESCRIPTION
I corresponded to #62 "Call to a member function roles() on null".