### PR TITLE
Update RedirectIfNotAuthenticated.stub

### DIFF
--- a/stubs/Middleware/RedirectIfNotAuthenticated.stub
+++ b/stubs/Middleware/RedirectIfNotAuthenticated.stub
@@ -2,27 +2,22 @@
 
 namespace {{namespace}}\Http\Middleware;
 
-use Closure;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
 
-class RedirectIfNot{{singularClass}}
+class RedirectIfNot{{singularClass}} extends Middleware
 {
 
     /**
-     * Handle an incoming request.
+     * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @param  string|null  $guard
-     * @return mixed
+     * @return string|null
      */
-    public function handle($request, Closure $next, $guard = '{{singularSnake}}')
+    protected function redirectTo($request)
     {
-        if (!Auth::guard($guard)->check()) {
-            return redirect('{{singularSlug}}/login');
+        if (! $request->expectsJson()) {
+            return '/{{singularSlug}}/login';
         }
-
-        return $next($request);
     }
 
 }


### PR DESCRIPTION
This change is  to make the MultiAuth system compatible with Laravel default Authentication process and to behave identical as "web guard" or "User Model".
  
Actually there is a little problem if we use 
 ```php
public function handle($request, Closure $next, $guard = 'student')
    {
        if (!Auth::guard($guard)->check()) {
            
            return redirect('student\login');
        }

        return $next($request);
     }

```
as it is not go through the following method in 
```php
//Illuminate\Foundation\Exceptions\Handler.php;

/**
     * Convert an authentication exception into a response.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Illuminate\Auth\AuthenticationException  $exception
     * @return \Symfony\Component\HttpFoundation\Response
     */
    protected function unauthenticated($request, AuthenticationException $exception)
    {
        return $request->expectsJson()
                    ? response()->json(['message' => $exception->getMessage()], 401)
                    : redirect()->guest($exception->redirectTo() ?? route('login'));
    }
````
in this method `redirect()->guest()` play a role to set Intended Url **`$this->setIntendedUrl($intended);`** .

So, for your newly created guard` i.e. "student" `if you not go through $this->setIntendedUrl($intended);  in "unauthenticated" situation  then after authentication rather than redirect to "student dashboard" it will redirect to previously set Indented Url.

***To understand this you can check it. Do the following....***

> - Two guards -  User(web/default) and student
> 
> - in logout condition
> 1.  first visit domain.test/home [ _`user home page, don't login`_]
>  2.  then visit domain.test/student [_`student dashboard and do login in student`_]
> 
>  - after student successful login it will redirect to domain.test/login instead of domain.test/student.

##### This change has no direct impact on usability, it just modify the internal mechanism of authentication via middleware.