### PR TITLE
Make credentials configurable

### DIFF
--- a/config/multiauth.php
+++ b/config/multiauth.php
@@ -75,4 +75,17 @@ return [
         'role'           => Bitfumes\Multiauth\Model\Role::class,
         'permission'     => Bitfumes\Multiauth\Model\Permission::class,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Admin Credentials
+    |--------------------------------------------------------------------------
+    |
+    | When attempting a login the following additional credentials are
+    | provided to the authenticator to check in the admins table.
+    |
+    */
+    'credentials' => [
+        'active' => 1,
+    ],
 ];

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -132,6 +132,30 @@ You can set your own model and define here to use by package.
         'role'           => Bitfumes\Multiauth\Model\Role::class,
         'permission'     => Bitfumes\Multiauth\Model\Permission::class,
     ],
+
+...
+```
+
+## Credentials
+
+You can set your own credentials to be passed to the authenticator with the username and password.
+
+By default we check that the `active` column of the `admins` table is true.
+
+```php{11,12,13}
+...
+    /*
+    |--------------------------------------------------------------------------
+    | Admin Credentials
+    |--------------------------------------------------------------------------
+    |
+    | When attempting a login the following additional credentials are
+    | provided to the authenticator to check in the admins table.
+    |
+    */
+    'credentials' => [
+        'active' => 1,
+    ],
 ];
 
 

--- a/src/Http/Controllers/LoginController.php
+++ b/src/Http/Controllers/LoginController.php
@@ -61,9 +61,16 @@ class LoginController extends Controller
      */
     protected function credentials(Request $request)
     {
-        $request['active'] = 1;
+        $extraCredentials = config('multiauth.credentials', [
+            'active' => 1,
+        ]);
 
-        return $request->only($this->username(), 'password', 'active');
+        $request->merge($extraCredentials);
+
+        return $request->only(array_merge(
+            [$this->username(), 'password'],
+            array_keys($extraCredentials),
+        ));
     }
 
     /**


### PR DESCRIPTION
By default laravel-multiauth checks that `admins.active = 1`.

This change allows you to configure the credentials that are passed
along with the username and password by adding a `credentials` setting
to `config/multiauth.php`.

With this you can add additional columns to check, change the type of
the `active` value, or remove the `active` check altogether.