### PR TITLE
Fix PostgreSQL bug when creating new admins

### DIFF
--- a/src/Http/Requests/AdminRequest.php
+++ b/src/Http/Requests/AdminRequest.php
@@ -26,11 +26,11 @@ class AdminRequest extends FormRequest
     public function rules()
     {
         $email_rule = 'required|email|max:255|unique:admins,email';
-        $admin_id = request('admin.id');
+        $admin_id   = request('admin.id');
         if (!is_null($admin_id)) {
             $email_rule .= ",{$admin_id}";
         }
-        
+
         $rules    = [
             'name'     => 'required|max:255',
             'email'    => $email_rule,

--- a/src/Http/Requests/AdminRequest.php
+++ b/src/Http/Requests/AdminRequest.php
@@ -25,10 +25,15 @@ class AdminRequest extends FormRequest
      */
     public function rules()
     {
+        $email_rule = 'required|email|max:255|unique:admins,email';
         $admin_id = request('admin.id');
+        if (!is_null($admin_id)) {
+            $email_rule .= ",{$admin_id}";
+        }
+        
         $rules    = [
             'name'     => 'required|max:255',
-            'email'    => "required|email|max:255|unique:admins,email,{$admin_id}",
+            'email'    => $email_rule,
             'password' => 'required|min:8|confirmed',
             'role_id'  => 'required',
         ];


### PR DESCRIPTION
When creating a new admin the value of `request('admin.id')` is `NULL`, which means the email validation rule becomes `"required|email|max:255|unique:admins,email,"`.

This results in the SQL `select count(*) as aggregate from "admins" where "email" = 'test@example.com' and "id" <> ''`, which causes an exception in PostgreSQL: `SQLSTATE[22P02]: Invalid text representation: 7 ERROR: invalid input syntax for type bigint: ""`.

This change first checks that `request('admin.id')` is not `NULL` before adding it to the email uniqueness check.

Fixes #86 and fixes #114